### PR TITLE
update end of file check to adjust for aws s3 offset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-readstream",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Drop in AWS S3 replacement read stream",
   "main": "dist/S3Readstream.js",
   "types": "dist/S3Readstream.d.js",

--- a/src/S3Readstream.ts
+++ b/src/S3Readstream.ts
@@ -74,7 +74,7 @@ export class S3ReadStream extends Readable {
   }
 
 	_read() {
-		if (this._currentCursorPosition > this._maxContentLength) {
+		if (this._currentCursorPosition >= this._maxContentLength) {
 			this.push(null);
 		} else {
 			const range = this._currentCursorPosition + this._s3DataRange;


### PR DESCRIPTION
This pr is addressing issue #1.

Since `this._maxContentLength` is the number of bytes while the range of bytes is actually `0 - this._maxContentLength - 1`; a bug occurred on the edge case of trying to grab a byte range of `this._maxContentLength - this._maxContentLength`. This was due to the [byte offset ](https://www.rfc-editor.org/rfc/rfc7233#section-2.1) not being properly accounted for.